### PR TITLE
Orchestrated IAM Security

### DIFF
--- a/security/.terraform.lock.hcl
+++ b/security/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.93.0"
+  hashes = [
+    "h1:ODfuqpsLGW3WShNNPgImLOOXlphVs4u/fFdLkScqi8U=",
+    "zh:00e1b15e6f02cdc788fe855232b63ccce6652930080eac3ba4b8a2e35db02b23",
+    "zh:3a77ee12e4f5ab2e7b320a0f507389c9171ab82c50d39ae7caa5a1fb2bd95cb3",
+    "zh:3e32d58e139d098d867eef37914fef01fffb08504d828e0f384c2ffc18d71f80",
+    "zh:41cf69a525f0fbe0fdb71d26be7ff5e20bb90ccdf5af32c83ed53f0ca2f071b5",
+    "zh:43055bdd0786855cf7242638a74b579f74f4f1a8e7c7e5e0e50230c8f6b908cb",
+    "zh:4ac4c29aa0de842ad91145c5a5fba21338531ffca13a510927d445e007a24938",
+    "zh:57e510498b3aeb6d6155c10fa195e1d5502e763899251057e59e73f653d1e262",
+    "zh:8f749645b27dba1a07d06aaf9d5596fc4213123f12f3808d68539e78ab16996e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aaca5934ac6273d48922ad7685c5fc2aa7ef5275346a9e70366b7a180a788d41",
+    "zh:b7585b720a97467302f2e29f0688a5a746778f7b73c30eb085c25831decba1e1",
+    "zh:c16ae0a46d796858c49a89dd90e5ca92f793e646474fadeafaf701def4a4aa83",
+    "zh:d66bdc9cd5108452d9dba44082e504ff5e3a3001c8f853bbcaff850cb2127a21",
+    "zh:ee1aec6c44b117a6c8b7159ee7dc82f1ddac6ba434b4e6c493717738326f0a99",
+    "zh:f0da48692e00ecacea72d7104714d9721f6be40ba094490c442bb3e68d2e2604",
+  ]
+}

--- a/security/main.tf
+++ b/security/main.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role" "ecs_task_role" {
+  name = "ecs_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+        Effect = "Allow"
+        Principal = {
+            Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+    }]
+  })
+  tags = {
+    Name = "ECS task role"
+  }
+}
+resource "aws_iam_policy_attachment" "ec2_task_execution_policy" {
+    name = "ec2-task-attachment-execution-policy"
+  roles = [aws_iam_role.ecs_task_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/security/output.tf
+++ b/security/output.tf
@@ -1,0 +1,3 @@
+output "ecs_task_role_arn" {
+  value = aws_iam_role.ecs_task_role.arn
+}


### PR DESCRIPTION
This PR introduces IAM roles and policies required for ECS Fargate task execution. It includes:

Creation of an IAM role (ecs_task_role) with permissions for ECS tasks to assume the role.

Attachment of the AmazonECSTaskExecutionRolePolicy to allow ECS tasks to pull images and log execution details.

