### PR TITLE
Set up ECS Fargate service with private subnets and security group

### DIFF
--- a/compute/main.tf
+++ b/compute/main.tf
@@ -1,3 +1,21 @@
+resource "aws_security_group" "ecs_sg" {
+    name = "fargate-sg"
+    description = "Security Group for Fargate"
+    vpc_id = aws_vpc.main_vpc.id
+    #Defining the inbound rule
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [aws_security_group.alb_sg.id]
+    }
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
 resource "aws_ecs_cluster" "ecs_cluster" {
     name = "main-cluster"
    
@@ -9,6 +27,38 @@ resource "aws_ecs_task_definition" "app_task" {
   family = "my-app-task"
   network_mode = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  execution_role_arn = aws_iam_role.ec2_task_execution_role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn = aws_iam_role.ecs_task_role.arn
+  cpu = "250"
+  memory = "500"
+  container_definitions = jsonencode([
+{
+    name = "my-app-container"
+    image = "nginx:latest"
+    cpu = 250
+    memory = 500
+    essential = true
+    portMappings = [
+        {
+        containerPort = 80
+        hostPort = 80
+        protocol = "tcp"
+        }
+        
+    ]
+}
+])
+}
+resource "aws_ecs_service" "fargate_service" {
+    name = "fargate-service"
+    cluster = aws_ecs_cluster.ecs_cluster.id
+    task_definition = aws_ecs_task_definition.app_task.arn
+    desired_count = 1
+    launch_type = "FARGATE"
+    network_configuration {
+      subnets = [aws_private_subnet_cidr_1.id, aws_private_subnet_cidr_2.id]
+      security_groups = [aws_security_group.ecs_sg.id]
+      assign_public_ip = false
+    }
+  
 }


### PR DESCRIPTION
- Defined ECS security group with inbound rules for ALB communication.
- Created ECS task definition for Nginx container.
- Configured ECS service to deploy tasks in two private subnets.
- Ensured the service uses Fargate launch type with no public IP assignment.